### PR TITLE
Add getters for warning/suggestion keys

### DIFF
--- a/src/main/java/me/gosimple/nbvcxz/resources/Feedback.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/Feedback.java
@@ -48,6 +48,16 @@ public class Feedback
     }
 
     /**
+     * Get the raw untranslated warning key.
+     *
+     * @return the warning key (nullable)
+     */
+    public String getWarningKey()
+    {
+        return warning;
+    }
+
+    /**
      * @return the warning (nullable)
      */
     public String getWarning()
@@ -60,6 +70,16 @@ public class Feedback
         {
             return null;
         }
+    }
+
+    /**
+     * Get the raw untranslated suggestion keys.
+     *
+     * @return list of suggestion keys (list is not null)
+     */
+    public List<String> getSuggestionKeys()
+    {
+        return suggestions;
     }
 
     /**


### PR DESCRIPTION
Add two getters to `Feedback` for retrieving the (untranslated) keys
used for warnings and suggestions. This allows automated analysis of
common suggestions, and gives consumers of the library a way to style
certain messages based on a generic key instead of the actual message
(which differs for each language).