### PR TITLE
Return suggestions only when appropriate

### DIFF
--- a/src/main/java/me/gosimple/nbvcxz/resources/CharacterCaseUtil.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/CharacterCaseUtil.java
@@ -1,0 +1,35 @@
+package me.gosimple.nbvcxz.resources;
+
+public class CharacterCaseUtil {
+    /**
+     * Of the characters in the string that have an uppercase form, how many are uppercased?
+     *
+     * @param input Input string.
+     * @return The fraction of uppercased characters, with {@code 0.0d} meaning that all uppercasable characters are in
+     * lowercase and {@code 1.0d} that all of them are in uppercase.
+     */
+    public static double fractionOfStringUppercase(String input)
+    {
+        if (input == null) return 0;
+
+        double upperCasableCharacters = 0;
+        double upperCount = 0;
+        for (int i = 0; i < input.length(); i++)
+        {
+            char c = input.charAt(i);
+            char uc = Character.toUpperCase(c);
+            char lc = Character.toLowerCase(c);
+            // If both the upper and lowercase version of a character are the same, then the character has
+            // no distinct uppercase form (e.g., a digit or punctuation). Ignore these.
+            if (c == uc && c == lc) continue;
+
+            upperCasableCharacters++;
+            if (c == uc)
+            {
+                upperCount++;
+            }
+        }
+
+        return upperCasableCharacters == 0 ? 0 : upperCount / upperCasableCharacters;
+    }
+}

--- a/src/main/java/me/gosimple/nbvcxz/resources/Feedback.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/Feedback.java
@@ -40,6 +40,19 @@ public class Feedback
     }
 
     /**
+     * @param configuration the {@link Configuration} object.
+     * @param warning       warning string
+     * @param suggestions   suggestions
+     */
+    public Feedback(final Configuration configuration, final String result, final String warning, final List<String> suggestions)
+    {
+        this.configuration = configuration;
+        this.result = result;
+        this.warning = warning;
+        this.suggestions = new ArrayList<>(suggestions);
+    }
+
+    /**
      * @return if the password was secure enough or not (not null)
      */
     public String getResult()

--- a/src/main/java/me/gosimple/nbvcxz/resources/FeedbackUtil.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/FeedbackUtil.java
@@ -3,6 +3,9 @@ package me.gosimple.nbvcxz.resources;
 import me.gosimple.nbvcxz.matching.match.*;
 import me.gosimple.nbvcxz.scoring.Result;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * @author Adam Brusselback.
@@ -106,7 +109,34 @@ public class FeedbackUtil
                 warning = "feedback.dictionary.warning.passwords.veryCommon";
             }
 
-            return new Feedback(configuration, "main.feedback.insecure", warning, "feedback.dictionary.suggestions.allUppercase", "feedback.dictionary.suggestions.capitalization", "feedback.dictionary.suggestions.leet", "feedback.dictionary.suggestions.reversed", "feedback.extra.suggestions.addAnotherWord");
+            List<String> suggestions = new ArrayList<>();
+
+            // A generic suggestion in lieu of other more specific suggestions.
+            suggestions.add("feedback.extra.suggestions.addAnotherWord");
+
+            if (dictionaryMatch.isReversed())
+            {
+                suggestions.add("feedback.dictionary.suggestions.reversed");
+            }
+
+            if (dictionaryMatch.isLeet())
+            {
+                suggestions.add("feedback.dictionary.suggestions.leet");
+            }
+
+            double capitalizationFraction = CharacterCaseUtil.fractionOfStringUppercase(result.getPassword());
+            if (capitalizationFraction > 0.8d)
+            {
+                // Nearly all characters were capitalized.
+                suggestions.add("feedback.dictionary.suggestions.allUppercase");
+            }
+            else if (capitalizationFraction > 0.0d)
+            {
+                // Some characters were capitalized.
+                suggestions.add("feedback.dictionary.suggestions.capitalization");
+            }
+
+            return new Feedback(configuration, "main.feedback.insecure", warning, suggestions);
 
         }
         return getDefaultFeedback(configuration);

--- a/src/test/java/me/gosimple/nbvcxz/resources/CharacterCaseUtilTest.java
+++ b/src/test/java/me/gosimple/nbvcxz/resources/CharacterCaseUtilTest.java
@@ -1,0 +1,30 @@
+package me.gosimple.nbvcxz.resources;
+
+import org.junit.Test;
+
+import static me.gosimple.nbvcxz.resources.CharacterCaseUtil.fractionOfStringUppercase;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class CharacterCaseUtilTest {
+    @Test
+    public void fractionOfStringUppercaseDoNotFailOnNullTest()
+    {
+        assertThat(fractionOfStringUppercase(null), is(0.0d));
+    }
+
+    @Test
+    public void fractionOfStringUppercaseTest()
+    {
+        assertThat(fractionOfStringUppercase("TEST"), is(1.0d));
+        assertThat(fractionOfStringUppercase("test"), is(0.0d));
+        assertThat(fractionOfStringUppercase("teST"), is(0.5d));
+
+        // Assert that characters without uppercase form are ignored.
+        assertThat(fractionOfStringUppercase("TEST 5!"), is(1.0d));
+        assertThat(fractionOfStringUppercase("test 5!"), is(0.0d));
+        assertThat(fractionOfStringUppercase("teST 5!"), is(0.5d));
+
+        assertThat(fractionOfStringUppercase("HaMbUrGer"), is(0.4444444444444444d));
+    }
+}


### PR DESCRIPTION
Instead of returning a list of generic suggestions for a `DictionaryMatch`, attempt to tailor the suggestions to the input.

This PR depends a bit on how you've intended the suggestions to be used. I would expect that only relevant suggestions are returned (because any application using this library will likely provide a list of generic tips itself). So if you submit `dictionary`, then you won't get the 'all-caps' suggestion, but you do if you submit `DICTIONARY`.

This PR is my naive attempt at solving this issue. Is this an approach worth considering?

I have tried to match your code style; my apologies if anything is formatted wrongly.