### PR TITLE
Fixing some typos on portuguese bundle

### DIFF
--- a/src/main/resources/feedback_pt.properties
+++ b/src/main/resources/feedback_pt.properties
@@ -1,34 +1,33 @@
 # Feedback
 ## Default
-feedback.default.suggestions.useFewWords=Use poucas palavras, evite frases comuns.
-feedback.default.suggestions.noNeedSymbols=Sem necessidade de símbulos, dígitos ou letras maiúsculas.
+feedback.default.suggestions.useFewWords=Use poucas palavras, evitando frases comuns.
+feedback.default.suggestions.noNeedSymbols=N\u00E3o \u00E9 necess\u00E1rio usar s\u00EDmbolos, d\u00EDgitos ou letras mai\u00FAsculas.
 ## Extra
-feedback.extra.suggestions.addAnotherWord=Adicione uma ou duas palavras. Palavras incomuns são melhores.
+feedback.extra.suggestions.addAnotherWord=Adicione uma ou mais palavras. Palavras pouco usuais s\u00E3o melhores.
 ## Dictionary
-feedback.dictionary.warning.passwords.notAllowed=Essa senha não é permitida para uso.
-feedback.dictionary.warning.passwords.top10=Isso é um top-10 de senhas comuns.
-feedback.dictionary.warning.passwords.top100=Isso é um top-100 de senhas comuns.
-feedback.dictionary.warning.passwords.veryCommon=Essa é uma senha muito comun.
-feedback.dictionary.suggestions.capitalization=Letra maiúscula não ajuda muito.
-feedback.dictionary.suggestions.allUppercase=Tudo maíusculo é tão fácil de adivinhar quanto tudo minúsculo.
-feedback.dictionary.suggestions.reversed=Palavras inversas não são tão difíceis de adivinhar.
-####Reversed words aren't much harder to guess.
-feedback.dictionary.suggestions.leet=Substituições prevísiveis como '@' no lugar de 'a' não ajudam muito.
-feedback.dictionary.suggestions.passwords.notAllowed=Por favor, tente uma senha diferente que não esteja na lista de exclusão, adicione palavras ou digitos extras.
+feedback.dictionary.warning.passwords.notAllowed=N\u00E3o \u00E9 permitido usar esta senha.
+feedback.dictionary.warning.passwords.top10=Esta \u00E9 uma das 10 senhas mais utilizadas.
+feedback.dictionary.warning.passwords.top100=Esta \u00E9 uma das 100 senhas mais utilizadas.
+feedback.dictionary.warning.passwords.veryCommon=Esta \u00E9 uma senha muito comum.
+feedback.dictionary.suggestions.capitalization=Letras mai\u00FAsculas n\u00E3o s\u00E3o muito \u00FAteis.
+feedback.dictionary.suggestions.allUppercase=Palavras mai\u00FAsculas s\u00E3o t\u00E3o f\u00E1ceis de adivinhar quanto min\u00FAsculas.
+feedback.dictionary.suggestions.reversed=Palavras invertidas n\u00E3o s\u00E3o muito dif\u00EDceis de adivinhar.
+feedback.dictionary.suggestions.leet=Substitui\u00E7\u00F5es previs\u00EDveis como "@" ao inv\u00E9s de "a" n\u00E3o s\u00E3o muito \u00FAteis.
+feedback.dictionary.suggestions.passwords.notAllowed=Tente uma senha diferente que n\u00E3o esteja na lista de exclus\u00F5es, adicionando outras palavras ou n\u00FAmeros.
 ## Spatial
-feedback.spatial.warning.straightRowsOfKeys=Teclas em uma fileira direta são fáceis de adivinhar.
-feedback.spatial.warning.shortKeyboardPatterns=Padrões curtos do teclado são fáceis de adivinhar.
-feedback.spatial.suggestions.UseLongerKeyboardPattern=Use a longer keyboard pattern with more turns.
+feedback.spatial.warning.straightRowsOfKeys=Teclas em sequ\u00EAncia s\u00E3o f\u00E1ceis de adivinhar.
+feedback.spatial.warning.shortKeyboardPatterns=Padr\u00F5es de teclado com teclas pr\u00F3ximas s\u00E3o f\u00E1ceis de adivinhar.
+feedback.spatial.suggestions.UseLongerKeyboardPattern=Use um padr\u00E3o de teclado com teclas mais distantes.
 ## Repeat
-feedback.repeat.warning.likeAAA=Repetições como "aaa" são faceis de adivinhar.
-feedback.repeat.warning.likeABCABCABC=Repetições como "abcabcabc" são apenas um pouco mais difíceis de se adivinhar do que "abc".
+feedback.repeat.warning.likeAAA=Repeti\u00E7\u00F5es como "aaa" s\u00E3o muito f\u00E1ceis de adivinhar.
+feedback.repeat.warning.likeABCABCABC=Repeti\u00E7\u00F5es como "abcabcabc" s\u00E3o apenas um pouco mais dif\u00EDceis de adivinhar quanto "abc".
 feedback.repeat.suggestions.avoidRepeated=Evite utilizar palavras ou caracteres repetidos.
 ## Sequence
-feedback.sequence.warning.sequenceWarning=Sequências como abc ou 6543 são faceis de adivinhar.
-feedback.sequence.suggestions.avoidSequences=Evite sequências.
+feedback.sequence.warning.sequenceWarning=Sequ\u00EAncias como "abc" ou "6543" s\u00E3o f\u00E1ceis de adivinhar.
+feedback.sequence.suggestions.avoidSequences=Evite sequ\u00EAncias.
 ## Year
-feedback.year.warning.recentYears=Anos recentes são faceis de adivinhar.
-feedback.year.suggestions.avoidYears=Evite anos recentes, evite anos associados a você.
+feedback.year.warning.recentYears=Anos recentes s\u00E3o f\u00E1ceis de adivinhar.
+feedback.year.suggestions.avoidYears=Evite anos recentes, evite anos que podem estar associados a voc\u00EA.
 ## Date
-feedback.date.warning.dates=Datas são muitas vezes fáceis de adivinhar.
-feedback.date.suggestions.avoidDates=Evite datas e anos associados a você.
+feedback.date.warning.dates=Datas s\u00E3o muitas vezes f\u00E1ceis de adivinhar.
+feedback.date.suggestions.avoidDates=Evite datas que podem estar associados a voc\u00EA.


### PR DESCRIPTION
Portuguese is my mother language, and I found some typos on pt bundle. So I'm contributing with my changes to upstream. All words are following the last spelling reform, so I believe it will work for all countries who speaks Portuguese.

I also changed bundle values to Unicode because the current version on master branch are printing messages like "RepetiÃ§Ãµes" instead of "Repetições".

Thank you.