### PR TITLE
Fix bug in StartIndexComparator violating comparator contracts.

### DIFF
--- a/src/main/java/me/gosimple/nbvcxz/Nbvcxz.java
+++ b/src/main/java/me/gosimple/nbvcxz/Nbvcxz.java
@@ -656,7 +656,7 @@ public class Nbvcxz
                 {
                     return -1;
                 }
-                else
+                else if (match_1.getToken().length() > match_2.getToken().length())
                 {
                     return 1;
                 }


### PR DESCRIPTION
This can yield a IllegalArgumentException: "Comparison method violates its general contract!" when it is used.