### PR TITLE
Implemented an "unmunger"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/me/gosimple/nbvcxz/matching/DictionaryMatcher.java
+++ b/src/main/java/me/gosimple/nbvcxz/matching/DictionaryMatcher.java
@@ -56,6 +56,11 @@ public final class DictionaryMatcher implements PasswordMatcher
 
         final List<String> translations = new ArrayList<>();
 
+        // do not bother continuing if we're going to replace every single character
+        if (chain.allReplaced()) {
+            return translations;
+        }
+
         if (chain.size() > 1)
         {
             // recursively generate all password permutations using the discovered munges

--- a/src/main/java/me/gosimple/nbvcxz/matching/DictionaryMatcher.java
+++ b/src/main/java/me/gosimple/nbvcxz/matching/DictionaryMatcher.java
@@ -4,6 +4,8 @@ import me.gosimple.nbvcxz.matching.match.DictionaryMatch;
 import me.gosimple.nbvcxz.matching.match.Match;
 import me.gosimple.nbvcxz.resources.Configuration;
 import me.gosimple.nbvcxz.resources.Dictionary;
+import me.gosimple.nbvcxz.resources.MungeTable;
+import me.gosimple.nbvcxz.resources.PasswordChain;
 
 import java.util.*;
 
@@ -417,88 +419,5 @@ public final class DictionaryMatcher implements PasswordMatcher
         }
         // Return all the matches
         return matches;
-    }
-}
-
-/**
- * Represents password permutations, using a list of candidate substrings. For instance, the first permutation
- * of the full password would be the 0th string from each part of the chain. This class is used to exhaust
- * password munging combinations.
- */
-class PasswordChain {
-    // substring candidates
-    private List<String[]> parts;
-    // a bijection with the list above, where each index specifies if the candidate parts at an index have
-    // already been completely unmunged
-    private List<Boolean> converted;
-
-    /**
-     * Creates a password chain using an initial String value.
-     */
-    public PasswordChain(String originalPassword) {
-        this.parts = new ArrayList<>();
-        this.converted = new ArrayList<>();
-
-        add(0, new String[] {originalPassword}, false);
-    }
-
-    /**
-     * Gets the password part at an index, if it contains the munge key
-     * and has not been substituted yet.
-     * @param index Index of the part to return
-     * @param key The munge key
-     * @return Single password part, containing the munge key, or null if the requirements were not met
-     */
-    public String getPartIfContainsKey(int index, String key) {
-        String[] subParts = parts.get(index);
-        String firstPart = subParts[0];
-        if (!converted.get(index) && firstPart.contains(key)) {
-            return firstPart;
-        }
-        else {
-            return null;
-        }
-    }
-
-    /**
-     * Replaces a part of the chain with possible substitutes.
-     * @param index Index of the part of the chain to replace
-     * @param subs Possible password munging substitutes
-     * @param converted Should be true if subs is the result of unmunging a part of the original password, false otherwise
-     */
-    public void replace(int index, String[] subs, boolean converted) {
-        parts.set(index, subs);
-        this.converted.set(index, converted);
-    }
-
-    /**
-     * Adds a list of possible password unmunge substitutes to a specific index in the chain.
-     * @param index Index to insert the candidates at
-     * @param subs Possible password munging substitutes
-     * @param converted Should be true if subs is the result of unmunging a part of the original password, false otherwise
-     */
-    public void add(int index, String[] subs, boolean converted) {
-        parts.add(index, subs);
-        this.converted.add(index, converted);
-    }
-
-    /**
-     * @return 2D string array representation of this password chain
-     */
-    public String[][] getParts() {
-        // convert List of String[] to String[][]
-        String[][] replacements = new String[parts.size()][];
-        for (int i = 0; i < parts.size(); i++) {
-            replacements[i] = parts.get(i);
-        }
-
-        return replacements;
-    }
-
-    /**
-     * @return Size of the chain
-     */
-    public int size() {
-        return parts.size();
     }
 }

--- a/src/main/java/me/gosimple/nbvcxz/matching/MungeTable.java
+++ b/src/main/java/me/gosimple/nbvcxz/matching/MungeTable.java
@@ -1,0 +1,80 @@
+package me.gosimple.nbvcxz.matching;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * A table mapping "munged" versions of a password substring to all the possible
+ * "unmunged" versions. For example, a password may contain a '1' that is used in place of an 'I'.
+ * This class was created to solve issue #45. It allows arbitrary substrings to be replaced with arbitrary strings.
+ * For example, "uu" can be used in place of 'w'. This class can also be used to do typical leetspeak substitutions,
+ * such as 4 -> A.
+ *
+ * See here for more on password munging: https://en.wikipedia.org/wiki/Munged_password
+ */
+public class MungeTable {
+    // regex used to split a password by a certain munge string (taking the place of %s)
+    private static final String splitRegex = "((?<=\\Q%s\\E)|(?=\\Q%s\\E))";
+    // mapping of munged strings -> possible unmunged replacements
+    private Map<String, String[]> table;
+    // keys from above, that should be sorted in order of descending key length
+    private List<String> keys;
+    // map of munged strings -> replacement regex
+    private Map<String, Pattern> regexPatterns;
+
+    public MungeTable() {
+        table = new HashMap<>();
+        keys = new ArrayList<>();
+        regexPatterns = new HashMap<>();
+    }
+
+    /**
+     * Adds a munged -> unmunged mapping to the table.
+     * @param key Munged string
+     * @param subs Possible unmunged replacements
+     * @return This object, for use with method chaining
+     */
+    public MungeTable addSub(String key, String...subs) {
+        table.put(key, subs);
+        keys.add(key);
+        regexPatterns.put(key, Pattern.compile(String.format(splitRegex, key, key)));
+        return this;
+    }
+
+    /**
+     * Sorts the munge keys in descending order, so that larger password munges
+     * are replaced first. Shuold be called after all subs are added using {@link MungeTable#addSub(String, String...)}
+     */
+    public void sort() {
+        // sort keys by their length, descending
+        keys.sort(
+                (String k1, String k2) -> -Integer.compare(k1.length(), k2.length())
+        );
+    }
+
+    /**
+     * @return List of all munge keys. Should be sorted using {@link MungeTable#sort()}
+     */
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    /**
+     * If the given key is in the table of password munges, returns the list
+     * of possible unmunges. Otherwise, just returns the given key.
+     */
+    public String[] getSubsOrOriginal(String key) {
+        return table.getOrDefault(key, new String[] {key});
+    }
+
+    /**
+     * Returns the compiled regex pattern for a particular munged substring. This saves time,
+     * since the pattern doesn't have to be recompiled every time it is used.
+     */
+    public Pattern getKeyPattern(String key) {
+        return regexPatterns.get(key);
+    }
+}

--- a/src/main/java/me/gosimple/nbvcxz/resources/Configuration.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/Configuration.java
@@ -1,9 +1,6 @@
 package me.gosimple.nbvcxz.resources;
 
-import me.gosimple.nbvcxz.matching.DictionaryMatcher;
-import me.gosimple.nbvcxz.matching.PasswordMatcher;
-import me.gosimple.nbvcxz.matching.SpacialMatcher;
-import me.gosimple.nbvcxz.matching.YearMatcher;
+import me.gosimple.nbvcxz.matching.*;
 
 import java.util.List;
 import java.util.Locale;
@@ -22,7 +19,7 @@ public class Configuration
     private final Map<String, Long> guessTypes;
     private final List<Dictionary> dictionaries;
     private final List<AdjacencyGraph> adjacencyGraphs;
-    private final Map<Character, Character[]> leetTable;
+    private final MungeTable mungeTable;
     private final Pattern yearPattern;
     private final Double minimumEntropy;
     private final Locale locale;
@@ -36,20 +33,20 @@ public class Configuration
      * @param guessTypes                  Map of types of guesses, and associated guesses/sec
      * @param dictionaries                List of {@link Dictionary} to use for the {@link DictionaryMatcher}
      * @param adjacencyGraphs             List of adjacency graphs to be used by the {@link SpacialMatcher}
-     * @param leetTable                   Leet table for use with {@link DictionaryMatcher}
+     * @param mungeTable                   Munge table for use with {@link DictionaryMatcher}
      * @param yearPattern                 Regex {@link Pattern} for use with {@link YearMatcher}
      * @param minimumEntropy              Minimum entropy value passwords should meet
      * @param locale                      Locale for localized text and feedback
      * @param distanceCalc                Enable or disable levenshtein distance calculation for dictionary matches
      * @param combinationAlgorithmTimeout Timeout for the findBestMatches algorithm
      */
-    public Configuration(List<PasswordMatcher> passwordMatchers, Map<String, Long> guessTypes, List<Dictionary> dictionaries, List<AdjacencyGraph> adjacencyGraphs, Map<Character, Character[]> leetTable, Pattern yearPattern, Double minimumEntropy, Locale locale, boolean distanceCalc, long combinationAlgorithmTimeout)
+    public Configuration(List<PasswordMatcher> passwordMatchers, Map<String, Long> guessTypes, List<Dictionary> dictionaries, List<AdjacencyGraph> adjacencyGraphs, MungeTable mungeTable, Pattern yearPattern, Double minimumEntropy, Locale locale, boolean distanceCalc, long combinationAlgorithmTimeout)
     {
         this.passwordMatchers = passwordMatchers;
         this.guessTypes = guessTypes;
         this.dictionaries = dictionaries;
         this.adjacencyGraphs = adjacencyGraphs;
-        this.leetTable = leetTable;
+        this.mungeTable = mungeTable;
         this.yearPattern = yearPattern;
         this.minimumEntropy = minimumEntropy;
         this.locale = locale;
@@ -94,9 +91,9 @@ public class Configuration
     /**
      * @return Leet table for use with {@link DictionaryMatcher}
      */
-    public Map<Character, Character[]> getLeetTable()
+    public MungeTable getMungeTable()
     {
-        return leetTable;
+        return mungeTable;
     }
 
     /**

--- a/src/main/java/me/gosimple/nbvcxz/resources/ConfigurationBuilder.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/ConfigurationBuilder.java
@@ -1,14 +1,7 @@
 package me.gosimple.nbvcxz.resources;
 
 import me.gosimple.nbvcxz.Nbvcxz;
-import me.gosimple.nbvcxz.matching.DateMatcher;
-import me.gosimple.nbvcxz.matching.DictionaryMatcher;
-import me.gosimple.nbvcxz.matching.PasswordMatcher;
-import me.gosimple.nbvcxz.matching.RepeatMatcher;
-import me.gosimple.nbvcxz.matching.SeparatorMatcher;
-import me.gosimple.nbvcxz.matching.SequenceMatcher;
-import me.gosimple.nbvcxz.matching.SpacialMatcher;
-import me.gosimple.nbvcxz.matching.YearMatcher;
+import me.gosimple.nbvcxz.matching.*;
 import me.gosimple.nbvcxz.matching.match.Match;
 
 import java.math.BigDecimal;
@@ -33,7 +26,7 @@ public class ConfigurationBuilder
     private static final List<Dictionary> defaultDictionaries = new ArrayList<>();
     private static final List<PasswordMatcher> defaultPasswordMatchers = new ArrayList<>();
     private static final List<AdjacencyGraph> defaultAdjacencyGraphs = new ArrayList<>();
-    private static final Map<Character, Character[]> defaultLeetTable = new HashMap<>();
+    private static final MungeTable defaultMungeTable = new MungeTable();
     
     static 
     {
@@ -56,35 +49,56 @@ public class ConfigurationBuilder
         defaultAdjacencyGraphs.add(new AdjacencyGraph("Standard Keypad", AdjacencyGraphUtil.standardKeypad));
         defaultAdjacencyGraphs.add(new AdjacencyGraph("Mac Keypad", AdjacencyGraphUtil.macKeypad));
 
-        defaultLeetTable.put('4', new Character[]{'a'});
-        defaultLeetTable.put('@', new Character[]{'a'});
-        defaultLeetTable.put('8', new Character[]{'b'});
-        defaultLeetTable.put('(', new Character[]{'c'});
-        defaultLeetTable.put('{', new Character[]{'c'});
-        defaultLeetTable.put('[', new Character[]{'c'});
-        defaultLeetTable.put('<', new Character[]{'c'});
-        defaultLeetTable.put('3', new Character[]{'e'});
-        defaultLeetTable.put('9', new Character[]{'g'});
-        defaultLeetTable.put('6', new Character[]{'g'});
-        defaultLeetTable.put('&', new Character[]{'g'});
-        defaultLeetTable.put('#', new Character[]{'h'});
-        defaultLeetTable.put('!', new Character[]{'i', 'l'});
-        defaultLeetTable.put('1', new Character[]{'i', 'l'});
-        defaultLeetTable.put('|', new Character[]{'i', 'l'});
-        defaultLeetTable.put('0', new Character[]{'o'});
-        defaultLeetTable.put('$', new Character[]{'s'});
-        defaultLeetTable.put('5', new Character[]{'s'});
-        defaultLeetTable.put('+', new Character[]{'t'});
-        defaultLeetTable.put('7', new Character[]{'t', 'l'});
-        defaultLeetTable.put('%', new Character[]{'x'});
-        defaultLeetTable.put('2', new Character[]{'z'});
+        defaultMungeTable
+            // simple single character substitutions (mostly leet speak)
+            .addSub("4", "a")
+            .addSub("@", "a")
+            .addSub("8", "b")
+            .addSub("(", "c")
+            .addSub("{", "c")
+            .addSub("[", "c")
+            .addSub("<", "c", "k", "v")
+            .addSub(">", "v")
+            .addSub("3", "e")
+            .addSub("9", "g", "q")
+            .addSub("6", "d", "g")
+            .addSub("&", "g")
+            .addSub("#", "f", "h")
+            .addSub("!", "i", "l")
+            .addSub("1", "i", "l")
+            .addSub("|", "i", "l")
+            .addSub("0", "o")
+            .addSub("$", "s")
+            .addSub("5", "s")
+            .addSub("+", "t")
+            .addSub("7", "t", "l")
+            .addSub("%", "x")
+            .addSub("2", "z")
+            // extra "munged" variations from here: https://en.wikipedia.org/wiki/Munged_password
+            .addSub("?", "y") // (y = why?)
+            .addSub("uu", "w")
+            .addSub("vv", "w")
+            .addSub("nn", "m")
+            .addSub("2u", "uu", "w")
+            .addSub("2v", "vv", "w")
+            .addSub("2n", "nn", "m")
+            .addSub("2b", "bb")
+            .addSub("2d", "dd")
+            .addSub("2g", "gg")
+            .addSub("2l", "ll")
+            .addSub("2p", "pp")
+            .addSub("2t", "tt")
+            .addSub("\\/\\/", "w")
+            .addSub("/\\/\\", "m")
+            .addSub("|)", "d")
+            .sort();
     }
 
     private List<PasswordMatcher> passwordMatchers;
     private Map<String, Long> guessTypes;
     private List<Dictionary> dictionaries;
     private List<AdjacencyGraph> adjacencyGraphs;
-    private Map<Character, Character[]> leetTable;
+    private MungeTable leetTable;
     private Pattern yearPattern;
     private Double minimumEntropy;
     private Locale locale;
@@ -179,9 +193,9 @@ public class ConfigurationBuilder
     /**
      * @return The default table of common english leet substitutions
      */
-    public static Map<Character, Character[]> getDefaultLeetTable()
+    public static MungeTable getDefaultMungeTable()
     {
-        return defaultLeetTable;
+        return defaultMungeTable;
     }
 
     /**
@@ -282,7 +296,7 @@ public class ConfigurationBuilder
      * @param leetTable Map for leetTable
      * @return Builder
      */
-    public ConfigurationBuilder setLeetTable(Map<Character, Character[]> leetTable)
+    public ConfigurationBuilder setLeetTable(MungeTable leetTable)
     {
         this.leetTable = leetTable;
         return this;
@@ -419,7 +433,7 @@ public class ConfigurationBuilder
         }
         if (leetTable == null)
         {
-            leetTable = getDefaultLeetTable();
+            leetTable = getDefaultMungeTable();
         }
         if (yearPattern == null)
         {

--- a/src/main/java/me/gosimple/nbvcxz/resources/MungeTable.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/MungeTable.java
@@ -63,11 +63,18 @@ public class MungeTable {
     }
 
     /**
-     * If the given key is in the table of password munges, returns the list
-     * of possible unmunges. Otherwise, just returns the given key.
+     * @return List of possible substitutes for a given munged substring
      */
-    public String[] getSubsOrOriginal(String key) {
-        return table.getOrDefault(key, new String[] {key});
+    public String[] getSubs(String key) {
+        return table.get(key);
+    }
+
+    /**
+     * @param key Munged substring key
+     * @return True if the munged key can be replaced with substitutes (is in the table), false otherwise
+     */
+    public boolean isReplaceable(String key) {
+        return table.containsKey(key);
     }
 
     /**

--- a/src/main/java/me/gosimple/nbvcxz/resources/MungeTable.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/MungeTable.java
@@ -1,4 +1,4 @@
-package me.gosimple.nbvcxz.matching;
+package me.gosimple.nbvcxz.resources;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/me/gosimple/nbvcxz/resources/PasswordChain.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/PasswordChain.java
@@ -14,6 +14,8 @@ public class PasswordChain {
     // a bijection with the list above, where each index specifies if the candidate parts at an index have
     // already been completely unmunged
     private List<Boolean> converted;
+    // number of password characters that have not yet been replaced with substitutes
+    private int unconvertedRemaining;
 
     /**
      * Creates a password chain using an initial String value.
@@ -23,6 +25,7 @@ public class PasswordChain {
         this.converted = new ArrayList<>();
 
         add(0, new String[] {originalPassword}, false);
+        unconvertedRemaining = originalPassword.length();
     }
 
     /**
@@ -66,6 +69,15 @@ public class PasswordChain {
     }
 
     /**
+     * Record that a certain number of characters have been replaced when part of the chain
+     * has been replaced with substitutes.
+     * @param num Number of characters that were replaced with substitutes
+     */
+    public void recordCharsConverted(int num) {
+        unconvertedRemaining -= num;
+    }
+
+    /**
      * @return 2D string array representation of this password chain
      */
     public String[][] getParts() {
@@ -82,7 +94,7 @@ public class PasswordChain {
      * @return True if all of the parts of the chain have been replaced, false otherwise.
      */
     public boolean allReplaced() {
-        return converted.stream().allMatch(b -> b);
+        return unconvertedRemaining == 0;
     }
 
     /**

--- a/src/main/java/me/gosimple/nbvcxz/resources/PasswordChain.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/PasswordChain.java
@@ -1,0 +1,87 @@
+package me.gosimple.nbvcxz.resources;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents password permutations, using a list of candidate substrings. For instance, the first permutation
+ * of the full password would be the 0th string from each part of the chain. This class is used to exhaust
+ * password munging combinations.
+ */
+public class PasswordChain {
+    // substring candidates
+    private List<String[]> parts;
+    // a bijection with the list above, where each index specifies if the candidate parts at an index have
+    // already been completely unmunged
+    private List<Boolean> converted;
+
+    /**
+     * Creates a password chain using an initial String value.
+     */
+    public PasswordChain(String originalPassword) {
+        this.parts = new ArrayList<>();
+        this.converted = new ArrayList<>();
+
+        add(0, new String[] {originalPassword}, false);
+    }
+
+    /**
+     * Gets the password part at an index, if it contains the munge key
+     * and has not been substituted yet.
+     * @param index Index of the part to return
+     * @param key The munge key
+     * @return Single password part, containing the munge key, or null if the requirements were not met
+     */
+    public String getPartIfContainsKey(int index, String key) {
+        String[] subParts = parts.get(index);
+        String firstPart = subParts[0];
+        if (!converted.get(index) && firstPart.contains(key)) {
+            return firstPart;
+        }
+        else {
+            return null;
+        }
+    }
+
+    /**
+     * Replaces a part of the chain with possible substitutes.
+     * @param index Index of the part of the chain to replace
+     * @param subs Possible password munging substitutes
+     * @param converted Should be true if subs is the result of unmunging a part of the original password, false otherwise
+     */
+    public void replace(int index, String[] subs, boolean converted) {
+        parts.set(index, subs);
+        this.converted.set(index, converted);
+    }
+
+    /**
+     * Adds a list of possible password unmunge substitutes to a specific index in the chain.
+     * @param index Index to insert the candidates at
+     * @param subs Possible password munging substitutes
+     * @param converted Should be true if subs is the result of unmunging a part of the original password, false otherwise
+     */
+    public void add(int index, String[] subs, boolean converted) {
+        parts.add(index, subs);
+        this.converted.add(index, converted);
+    }
+
+    /**
+     * @return 2D string array representation of this password chain
+     */
+    public String[][] getParts() {
+        // convert List of String[] to String[][]
+        String[][] replacements = new String[parts.size()][];
+        for (int i = 0; i < parts.size(); i++) {
+            replacements[i] = parts.get(i);
+        }
+
+        return replacements;
+    }
+
+    /**
+     * @return Size of the chain
+     */
+    public int size() {
+        return parts.size();
+    }
+}

--- a/src/main/java/me/gosimple/nbvcxz/resources/PasswordChain.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/PasswordChain.java
@@ -79,6 +79,13 @@ public class PasswordChain {
     }
 
     /**
+     * @return True if all of the parts of the chain have been replaced, false otherwise.
+     */
+    public boolean allReplaced() {
+        return converted.stream().allMatch(b -> b);
+    }
+
+    /**
      * @return Size of the chain
      */
     public int size() {

--- a/src/test/java/me/gosimple/nbvcxz/matching/DictionaryMatcherTest.java
+++ b/src/test/java/me/gosimple/nbvcxz/matching/DictionaryMatcherTest.java
@@ -207,11 +207,11 @@ public class DictionaryMatcherTest
         // create a table of expected dictionary matches
         Map<String, String> mappings = new HashMap<>();
         mappings.put("P@55uu0rd", "password"); // uu = w (from issue #45)
-        mappings.put("/\\/\\3G4", "mega"); // /\/\ = m
+        mappings.put("/\\/\\3GA", "mega"); // /\/\ = m
         mappings.put("|)R!2b|3", "dribble"); // |) = D, 2b = bb
-        mappings.put("/\\/\\02!2l4", "mozilla"); // /\/\02!2l4 (2l = l)
-        mappings.put("802t13", "bottle"); // 2t = tt
-        mappings.put("nn!|)|)|3", "middle"); // nn = m
+        mappings.put("/\\/\\02!2la", "mozilla"); // /\/\02!2l4 (2l = l)
+        mappings.put("B02t13", "bottle"); // 2t = tt
+        mappings.put("nn!|)|)l3", "middle"); // nn = m
         mappings.put("so2n3", "some"); // 2n could mean nn or m, make sure 'm' is used
         mappings.put("pe2n", "penn"); // same as above, but expecting 2n = nn
 

--- a/src/test/java/me/gosimple/nbvcxz/matching/DictionaryMatcherTest.java
+++ b/src/test/java/me/gosimple/nbvcxz/matching/DictionaryMatcherTest.java
@@ -210,6 +210,8 @@ public class DictionaryMatcherTest
         mappings.put("/\\/\\3G4", "mega"); // /\/\ = m
         mappings.put("|)R!2b|3", "dribble"); // |) = D, 2b = bb
         mappings.put("/\\/\\02!2l4", "mozilla"); // /\/\02!2l4 (2l = l)
+        mappings.put("802t13", "bottle"); // 2t = tt
+        mappings.put("nn!|)|)|3", "middle"); // nn = m
         mappings.put("so2n3", "some"); // 2n could mean nn or m, make sure 'm' is used
         mappings.put("pe2n", "penn"); // same as above, but expecting 2n = nn
 


### PR DESCRIPTION
For issue #45 

Arbitrary string to string substitution implemented, so **"P@55uu0rd" -> "password"** works, as does **"8u2T3RfL?" -> "butterfly"** from the wikipedia page. I wrote **DictionaryMatcher.testArbitraryLengthSubstitutions()** to test a few more examples. **leetTable** has been replaced by the **MungeTable** class which facilitates some of the substituting. MungeTable is initialized in ConfigurationBuilder as before, you can try adding some more substitutions there, I just added the few from the wikipedia page and some extra ones that I thought up. **PasswordChain** is used to store the list of possible substring permutations. I rewrote **translateLeet** as **getUnmungedVariations**, and rewrote **replaceAtIndex**. They kind of work in the same way,  just with a list of String[] instead of an in-place char array. There are some very obscure limitations, but I doubt they could be much of an issue. Efficiency wise it's probably worse than before, but I guess it depends on what your expectations are. It still takes a fraction of a second to estimate a reasonably sized password, at least.

Also, I changed the pom.xml java version from 1.7 to 8 so I could use streams and lambdas, is that an issue?

Let me know if you want me to do more on this, I'm sure it's not perfect. There are loads of occurrences of "leet" in comments and method names etc. that should probably be something like "munge" now...