### PR TITLE
Fix violations of Sonar rule 2111

### DIFF
--- a/src/main/java/me/gosimple/nbvcxz/Nbvcxz.java
+++ b/src/main/java/me/gosimple/nbvcxz/Nbvcxz.java
@@ -76,7 +76,7 @@ public class Nbvcxz
     public static BigDecimal getGuessesFromEntropy(final Double entropy)
     {
         final Double guesses_tmp = Math.pow(2, entropy);
-        return new BigDecimal(guesses_tmp.isInfinite() ? Double.MAX_VALUE : guesses_tmp).setScale(0, RoundingMode.HALF_UP);
+        return BigDecimal.valueOf(guesses_tmp.isInfinite() ? Double.MAX_VALUE : guesses_tmp).setScale(0, RoundingMode.HALF_UP);
     }
 
     /**

--- a/src/main/java/me/gosimple/nbvcxz/scoring/Result.java
+++ b/src/main/java/me/gosimple/nbvcxz/scoring/Result.java
@@ -78,7 +78,7 @@ public class Result
     public BigDecimal getGuesses()
     {
         final Double guesses_tmp = Math.pow(2, getEntropy());
-        return new BigDecimal(guesses_tmp.isInfinite() ? Double.MAX_VALUE : guesses_tmp).setScale(0, RoundingMode.HALF_UP);
+        return BigDecimal.valueOf(guesses_tmp.isInfinite() ? Double.MAX_VALUE : guesses_tmp).setScale(0, RoundingMode.HALF_UP);
     }
 
     /**


### PR DESCRIPTION
Hi @Tostino ,

This PR fixes 1 violations of [Sonar Rule 2111: '"BigDecimal(double)" should not be used'](https://rules.sonarsource.com/java/RSPEC-2111). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2111](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#bigdecimaldouble-should-not-be-used-sonar-rule-2111).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.