### PR TITLE
Fix for returning the internal instances from ConfigurationBuilder

### DIFF
--- a/src/main/java/me/gosimple/nbvcxz/resources/ConfigurationBuilder.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/ConfigurationBuilder.java
@@ -98,7 +98,7 @@ public class ConfigurationBuilder
      */
     public static List<PasswordMatcher> getDefaultPasswordMatchers()
     {
-        return defaultPasswordMatchers;
+        return new ArrayList<>(defaultPasswordMatchers);
     }
 
     /**
@@ -168,7 +168,7 @@ public class ConfigurationBuilder
      */
     public static List<Dictionary> getDefaultDictionaries()
     {
-        return defaultDictionaries;
+        return new ArrayList<>(defaultDictionaries);
     }
 
     /**
@@ -176,7 +176,7 @@ public class ConfigurationBuilder
      */
     public static List<AdjacencyGraph> getDefaultAdjacencyGraphs()
     {
-        return defaultAdjacencyGraphs;
+        return new ArrayList<>(defaultAdjacencyGraphs);
     }
 
     /**
@@ -184,7 +184,7 @@ public class ConfigurationBuilder
      */
     public static Map<Character, Character[]> getDefaultLeetTable()
     {
-        return defaultLeetTable;
+        return new HashMap<>(defaultLeetTable);
     }
 
     /**

--- a/src/test/java/me/gosimple/nbvcxz/NbvcxzTest.java
+++ b/src/test/java/me/gosimple/nbvcxz/NbvcxzTest.java
@@ -1,5 +1,7 @@
 package me.gosimple.nbvcxz;
 
+import me.gosimple.nbvcxz.matching.PasswordMatcher;
+import me.gosimple.nbvcxz.matching.match.Match;
 import me.gosimple.nbvcxz.resources.Configuration;
 import me.gosimple.nbvcxz.resources.ConfigurationBuilder;
 import me.gosimple.nbvcxz.resources.Dictionary;
@@ -55,6 +57,21 @@ public class NbvcxzTest
         {
             assert false;
         }
+    }
+
+    @Test
+    public void testConcurrency()
+    {
+        List<PasswordMatcher> matchers = ConfigurationBuilder.getDefaultPasswordMatchers();
+        PasswordMatcher testMatcher = new PasswordMatcher() {
+            @Override
+            public List<Match> match(Configuration configuration, String password) {
+                return new ArrayList<>();
+            }
+        };
+        matchers.add(testMatcher);
+
+        Assert.assertFalse(ConfigurationBuilder.getDefaultPasswordMatchers().contains(testMatcher));
     }
 
     @Test


### PR DESCRIPTION
We previously returned the same instance for some getDefault* methods. This caused issues when people were trying to use the library in any environment with concurrency.