### PR TITLE
Implement an "unmunger" (second attempt)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/me/gosimple/nbvcxz/resources/Configuration.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/Configuration.java
@@ -1,9 +1,6 @@
 package me.gosimple.nbvcxz.resources;
 
-import me.gosimple.nbvcxz.matching.DictionaryMatcher;
-import me.gosimple.nbvcxz.matching.PasswordMatcher;
-import me.gosimple.nbvcxz.matching.SpacialMatcher;
-import me.gosimple.nbvcxz.matching.YearMatcher;
+import me.gosimple.nbvcxz.matching.*;
 
 import java.util.List;
 import java.util.Locale;
@@ -22,10 +19,11 @@ public class Configuration
     private final Map<String, Long> guessTypes;
     private final List<Dictionary> dictionaries;
     private final List<AdjacencyGraph> adjacencyGraphs;
-    private final Map<Character, Character[]> leetTable;
+    private final TrieNode trieNodeRoot;
     private final Pattern yearPattern;
     private final Double minimumEntropy;
     private final Integer maxLength;
+    private final Integer substituteComboLimit;
     private final Locale locale;
     private final boolean distanceCalc;
     private final ResourceBundle mainResource;
@@ -37,23 +35,24 @@ public class Configuration
      * @param guessTypes                  Map of types of guesses, and associated guesses/sec
      * @param dictionaries                List of {@link Dictionary} to use for the {@link DictionaryMatcher}
      * @param adjacencyGraphs             List of adjacency graphs to be used by the {@link SpacialMatcher}
-     * @param leetTable                   Leet table for use with {@link DictionaryMatcher}
+     * @param trieNodeRoot                Root trie node to help find possible string substitutions, for use with {@link DictionaryMatcher}
      * @param yearPattern                 Regex {@link Pattern} for use with {@link YearMatcher}
      * @param minimumEntropy              Minimum entropy value passwords should meet
      * @param locale                      Locale for localized text and feedback
      * @param distanceCalc                Enable or disable levenshtein distance calculation for dictionary matches
      * @param combinationAlgorithmTimeout Timeout for the findBestMatches algorithm
      */
-    public Configuration(List<PasswordMatcher> passwordMatchers, Map<String, Long> guessTypes, List<Dictionary> dictionaries, List<AdjacencyGraph> adjacencyGraphs, Map<Character, Character[]> leetTable, Pattern yearPattern, Double minimumEntropy, Integer maxLength, Locale locale, boolean distanceCalc, long combinationAlgorithmTimeout)
+    public Configuration(List<PasswordMatcher> passwordMatchers, Map<String, Long> guessTypes, List<Dictionary> dictionaries, List<AdjacencyGraph> adjacencyGraphs, TrieNode trieNodeRoot, Pattern yearPattern, Double minimumEntropy, Integer maxLength, Integer substituteComboLimit, Locale locale, boolean distanceCalc, long combinationAlgorithmTimeout)
     {
         this.passwordMatchers = passwordMatchers;
         this.guessTypes = guessTypes;
         this.dictionaries = dictionaries;
         this.adjacencyGraphs = adjacencyGraphs;
-        this.leetTable = leetTable;
+        this.trieNodeRoot = trieNodeRoot;
         this.yearPattern = yearPattern;
         this.minimumEntropy = minimumEntropy;
         this.maxLength = maxLength;
+        this.substituteComboLimit = substituteComboLimit;
         this.locale = locale;
         this.distanceCalc = distanceCalc;
         this.mainResource = ResourceBundle.getBundle("main", locale);
@@ -96,9 +95,9 @@ public class Configuration
     /**
      * @return Leet table for use with {@link DictionaryMatcher}
      */
-    public Map<Character, Character[]> getLeetTable()
+    public TrieNode getTrieNodeRoot()
     {
-        return leetTable;
+        return trieNodeRoot;
     }
 
     /**
@@ -122,6 +121,13 @@ public class Configuration
      */
     public Integer getMaxLength() {
         return maxLength;
+    }
+
+    /**
+     * @return The default maximum number of string combos to generate, based on the possible string substitutions.
+     */
+    public Integer getSubstituteComboLimit() {
+        return substituteComboLimit;
     }
 
     /**

--- a/src/main/java/me/gosimple/nbvcxz/resources/SubstitutionComboGen.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/SubstitutionComboGen.java
@@ -1,0 +1,70 @@
+package me.gosimple.nbvcxz.resources;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SubstitutionComboGen {
+    private final TrieNode trieRoot;
+
+    public SubstitutionComboGen(TrieNode trieRoot) {
+        this.trieRoot = trieRoot;
+    }
+
+    /**
+     * Generates all possible combinations of a string against the root {@link TrieNode}.
+     * @param str The string to generate combinations from
+     * @param limit Limit number of combinations to generate
+     * @return List of combinations
+     */
+    public List<String> getAllSubCombos(final String str, final int limit) {
+        final List<String> combos = new ArrayList<>();
+        getAllSubCombos(str, 0, new StringBuilder(), combos, limit);
+        return combos;
+    }
+
+    private void getAllSubCombos(final String substr, int index, StringBuilder buffer, final List<String> finalPasswords, final int limit)
+    {
+        if (finalPasswords.size() >= limit) return;
+
+        if (index == substr.length())
+        {
+            // reached the end; add the contents of the buffer to the list of combinations
+            finalPasswords.add(buffer.toString());
+            return;
+        }
+
+        final char firstChar = substr.charAt(index);
+
+        // first, generate all combos without doing a substitution at this index
+        buffer.append(firstChar);
+        getAllSubCombos(substr, index + 1, buffer, finalPasswords, limit);
+        buffer.setLength(buffer.length() - 1);
+
+        // next, exhaust all possible substitutions at this index
+        TrieNode cur = trieRoot;
+        for (int i = index; i < substr.length(); i++)
+        {
+            final char c = substr.charAt(i);
+            cur = cur.getChild(c);
+            if (cur == null)
+            {
+                return;
+            }
+
+            if (cur.isTerminal())
+            {
+                String[] subs = cur.getSubs();
+                for (String sub : subs)
+                {
+                    buffer.append(sub);
+                    // recursively build the rest of the string
+                    getAllSubCombos(substr, i + 1, buffer, finalPasswords, limit);
+                    // backtrack by ignoring the added postfix
+                    buffer.setLength(buffer.length() - sub.length());
+
+                    if (finalPasswords.size() >= limit) return;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/me/gosimple/nbvcxz/resources/TrieNode.java
+++ b/src/main/java/me/gosimple/nbvcxz/resources/TrieNode.java
@@ -1,0 +1,76 @@
+package me.gosimple.nbvcxz.resources;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a node in a trie of possible string substitutions.
+ */
+public class TrieNode
+{
+    private final Map<Character, TrieNode> children;
+    private String[] subs;
+
+    public TrieNode()
+    {
+        children = new HashMap<>();
+    }
+
+    /**
+     * Adds a list of possible substitutions for a given string to the node.
+     * @param key The string that can be substituted
+     * @param subs An array of possible substitutions
+     * @return The same node, for method chaining
+     */
+    public TrieNode addSub(String key, String...subs)
+    {
+        final char firstChar = key.charAt(0);
+        if (!children.containsKey(firstChar))
+        {
+            children.put(firstChar, new TrieNode());
+        }
+        TrieNode cur = children.get(firstChar);
+        for (int i = 1; i < key.length(); i++)
+        {
+            final char c = key.charAt(i);
+            if (!cur.hasChild(c))
+            {
+                cur.addChild(c);
+            }
+            cur = cur.getChild(c);
+        }
+        cur.setSubs(subs);
+
+        return this;
+    }
+
+    public TrieNode getChild(Character child) {
+        return children.get(child);
+    }
+
+    public boolean isTerminal()
+    {
+        return subs != null;
+    }
+
+    public String[] getSubs() {
+        return subs;
+    }
+
+    private void setSubs(String[] sub)
+    {
+        this.subs = sub;
+    }
+
+    private void addChild(Character child)
+    {
+        if (!hasChild(child)) {
+            children.put(child, new TrieNode());
+        }
+    }
+
+    private boolean hasChild(Character child)
+    {
+        return children.containsKey(child);
+    }
+}


### PR DESCRIPTION
For issue #45, and a complete rewrite of my first attempt a few years ago: #55

Instead of splitting by regex, I'm trying out using a [trie](https://en.wikipedia.org/wiki/Trie) here. Going character by character, that lets you identify possible substitutions cleanly in linear time. I think it's also more complete in terms of edge cases (ie. where a substitution key is a substring of another sub key)

Example part of the overall trie:
![image](https://user-images.githubusercontent.com/26788109/224081292-a5055471-4a62-4f0d-a0df-d4ac090748e5.png)

## Performance

In order to exhaust all possible substitutions though you do still have to build all combinations out recursively, so I *think* you can't escape the exponential runtime there. That's why the hard limit on total number of combinations is important. I've noticed though for very long password lengths, if you just copy paste some of the string substitution keys over and over, there's a slowdown. It can take more than a full second to estimate long passwords on my machine. But I suspect the source of the problem might be that this alg is running for every possible substring of the password on top. I'm not fully familiar with the overall structure and intentions of the project but maybe the generation of substrings and this new alg should be merged into one overall alg rather than multiplying eachother, if that makes sense.